### PR TITLE
Better traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 * Padding strategies (`NoPadding`, `ConstantPadding`, `ZeroPadding`)
 * Threshold module with Otsu and Mean threshold algorithms
 * Image transformations and functions to create affine transform matrices
+* Type alias `Image` for `ImageBase<OwnedRepr<T>, _>` replicated old `Image` type
+* Type alias `ImageView` for `ImageBase<ViewRepr<&'a T>, _>`
 
 ### Changed
 * Integrated Padding strategies into convolutions
 * Updated `ndarray-stats` to 0.2.0 adding `noisy_float` for median change
 * [INTERNAL] Disabled code coverage due to issues with tarpaulin and native libraries
+* Renamed `Image` to `ImageBase` which can take any implementor of the ndaray `Data` trait
 
 ### Removed 
 

--- a/src/core/colour_models.rs
+++ b/src/core/colour_models.rs
@@ -1,6 +1,6 @@
 use crate::core::traits::*;
-use crate::core::{normalise_pixel_value, Image};
-use ndarray::{prelude::*, s, Data, OwnedRepr, Zip};
+use crate::core::*;
+use ndarray::{prelude::*, s, Data, Zip};
 use num_traits::cast::{FromPrimitive, NumCast};
 use num_traits::{Num, NumAssignOps};
 use std::convert::From;
@@ -182,7 +182,7 @@ where
     (red, green, blue)
 }
 
-impl<U, T> From<Image<U, RGB>> for Image<OwnedRepr<T>, HSV>
+impl<U, T> From<ImageBase<U, RGB>> for Image<T, HSV>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -195,7 +195,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, RGB>) -> Self {
+    fn from(image: ImageBase<U, RGB>) -> Self {
         let mut res = Array3::<_>::zeros((image.rows(), image.cols(), HSV::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -211,7 +211,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, HSV>> for Image<OwnedRepr<T>, RGB>
+impl<T, U> From<ImageBase<U, HSV>> for Image<T, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -224,7 +224,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, HSV>) -> Self {
+    fn from(image: ImageBase<U, HSV>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -240,7 +240,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, RGB>> for Image<OwnedRepr<T>, Gray>
+impl<T, U> From<ImageBase<U, RGB>> for Image<T, Gray>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -253,7 +253,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, RGB>) -> Self {
+    fn from(image: ImageBase<U, RGB>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), Gray::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -271,7 +271,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Gray>> for Image<OwnedRepr<T>, RGB>
+impl<T, U> From<ImageBase<U, Gray>> for Image<T, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -284,7 +284,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, Gray>) -> Self {
+    fn from(image: ImageBase<U, Gray>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -298,7 +298,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, RGB>> for Image<OwnedRepr<T>, CIEXYZ>
+impl<T, U> From<ImageBase<U, RGB>> for Image<T, CIEXYZ>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -311,7 +311,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, RGB>) -> Self {
+    fn from(image: ImageBase<U, RGB>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), CIEXYZ::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -337,7 +337,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, CIEXYZ>> for Image<OwnedRepr<T>, RGB>
+impl<T, U> From<ImageBase<U, CIEXYZ>> for Image<T, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -350,7 +350,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<U, CIEXYZ>) -> Self {
+    fn from(image: ImageBase<U, CIEXYZ>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -376,312 +376,312 @@ where
     }
 }
 
-impl<S, T> From<Image<T, Generic3>> for Image<OwnedRepr<S>, RGB>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, RGB>
 where
-    T: Data<Elem = S>,
+    T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         image.into_type_raw()
     }
 }
 
-impl<S, T> From<Image<T, Generic3>> for Image<T, HSV>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, Generic3>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, Generic3>> for Image<OwnedRepr<S>, HSI>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, Generic3>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<T> From<Image<T, Generic3>> for Image<T, HSL>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, HSV>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, YCrCb>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, HSI>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIEXYZ>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, HSL>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIELAB>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, YCrCb>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIELUV>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, CIEXYZ>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Gray>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, CIELAB>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic1>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, RGBA>
+impl<T> From<ImageBase<T, Generic3>> for ImageBase<T, CIELUV>
 where
     T: Data,
 {
-    fn from(image: Image<T, Generic4>) -> Self {
+    fn from(image: ImageBase<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, RGB>> for Image<T, Generic3>
+impl<T> From<ImageBase<T, Generic1>> for ImageBase<T, Gray>
 where
     T: Data,
 {
-    fn from(image: Image<T, RGB>) -> Self {
+    fn from(image: ImageBase<T, Generic1>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<S, T> From<Image<T, HSV>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, HSV>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, HSI>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, HSI>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, HSL>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, HSL>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, YCrCb>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, YCrCb>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, CIEXYZ>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, CIEXYZ>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, CIELAB>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, CIELAB>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<S, T> From<Image<T, CIELUV>> for Image<OwnedRepr<S>, Generic3>
-where
-    T: Data<Elem = S>,
-{
-    fn from(image: Image<T, CIELUV>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<T> From<Image<T, RGBA>> for Image<T, Generic4>
+impl<T> From<ImageBase<T, Generic4>> for ImageBase<T, RGBA>
 where
     T: Data,
 {
-    fn from(image: Image<T, RGBA>) -> Self {
+    fn from(image: ImageBase<T, Generic4>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Gray>> for Image<T, Generic1>
+impl<T> From<ImageBase<T, RGB>> for ImageBase<T, Generic3>
 where
     T: Data,
 {
-    fn from(image: Image<T, Gray>) -> Self {
+    fn from(image: ImageBase<T, RGB>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T, U> From<Image<U, Generic5>> for Image<U, Generic4>
+impl<T> From<ImageBase<T, HSV>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, HSV>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, HSI>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, HSI>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, HSL>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, HSL>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, YCrCb>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, YCrCb>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, CIEXYZ>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, CIEXYZ>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, CIELAB>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, CIELAB>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, CIELUV>> for ImageBase<T, Generic3>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, CIELUV>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, RGBA>> for ImageBase<T, Generic4>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, RGBA>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T> From<ImageBase<T, Gray>> for ImageBase<T, Generic1>
+where
+    T: Data,
+{
+    fn from(image: ImageBase<T, Gray>) -> Self {
+        Self::from_data(image.data)
+    }
+}
+
+impl<T, U> From<ImageBase<U, Generic5>> for Image<T, Generic4>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic5>) -> Self {
+    fn from(image: ImageBase<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic5>> for Image<U, Generic3>
+impl<T, U> From<ImageBase<U, Generic5>> for Image<T, Generic3>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic5>) -> Self {
+    fn from(image: ImageBase<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic5>> for Image<U, Generic2>
+impl<T, U> From<ImageBase<U, Generic5>> for Image<T, Generic2>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic5>) -> Self {
+    fn from(image: ImageBase<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic5>> for Image<U, Generic1>
+impl<T, U> From<ImageBase<U, Generic5>> for Image<T, Generic1>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic5>) -> Self {
+    fn from(image: ImageBase<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic4>> for Image<U, Generic3>
+impl<T, U> From<ImageBase<U, Generic4>> for Image<T, Generic3>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic4>) -> Self {
+    fn from(image: ImageBase<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic4>> for Image<U, Generic2>
+impl<T, U> From<ImageBase<U, Generic4>> for Image<T, Generic2>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic4>) -> Self {
+    fn from(image: ImageBase<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic4>> for Image<OwnedRepr<T>, Generic1>
+impl<T, U> From<ImageBase<U, Generic4>> for Image<T, Generic1>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic4>) -> Self {
+    fn from(image: ImageBase<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic3>> for Image<OwnedRepr<T>, Generic2>
+impl<T, U> From<ImageBase<U, Generic3>> for Image<T, Generic2>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic3>) -> Self {
+    fn from(image: ImageBase<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic3>> for Image<OwnedRepr<T>, Generic1>
+impl<T, U> From<ImageBase<U, Generic3>> for Image<T, Generic1>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic3>) -> Self {
+    fn from(image: ImageBase<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic2>> for Image<OwnedRepr<T>, Generic1>
+impl<T, U> From<ImageBase<U, Generic2>> for Image<T, Generic1>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<U, Generic2>) -> Self {
+    fn from(image: ImageBase<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T, U> From<Image<U, Generic1>> for Image<OwnedRepr<T>, Generic5>
+impl<T, U> From<ImageBase<U, Generic1>> for Image<T, Generic5>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic1>) -> Self {
+    fn from(image: ImageBase<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -690,12 +690,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic2>> for Image<OwnedRepr<T>, Generic5>
+impl<T, U> From<ImageBase<U, Generic2>> for Image<T, Generic5>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic2>) -> Self {
+    fn from(image: ImageBase<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -704,12 +704,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic3>> for Image<U, Generic5>
+impl<T, U> From<ImageBase<U, Generic3>> for Image<T, Generic5>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic3>) -> Self {
+    fn from(image: ImageBase<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic3::channels()])
@@ -718,12 +718,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic4>> for Image<U, Generic5>
+impl<T, U> From<ImageBase<U, Generic4>> for Image<T, Generic5>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic4>) -> Self {
+    fn from(image: ImageBase<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic4::channels()])
@@ -732,12 +732,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic1>> for Image<U, Generic4>
+impl<T, U> From<ImageBase<U, Generic1>> for Image<T, Generic4>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic1>) -> Self {
+    fn from(image: ImageBase<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -746,12 +746,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic2>> for Image<U, Generic4>
+impl<T, U> From<ImageBase<U, Generic2>> for Image<T, Generic4>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic2>) -> Self {
+    fn from(image: ImageBase<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -760,12 +760,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic3>> for Image<U, Generic4>
+impl<T, U> From<ImageBase<U, Generic3>> for Image<T, Generic4>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic3>) -> Self {
+    fn from(image: ImageBase<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic3::channels()])
@@ -774,12 +774,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic1>> for Image<U, Generic3>
+impl<T, U> From<ImageBase<U, Generic1>> for Image<T, Generic3>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic1>) -> Self {
+    fn from(image: ImageBase<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -788,12 +788,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic2>> for Image<U, Generic3>
+impl<T, U> From<ImageBase<U, Generic2>> for Image<T, Generic3>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic2>) -> Self {
+    fn from(image: ImageBase<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -802,12 +802,12 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Generic1>> for Image<U, Generic2>
+impl<T, U> From<ImageBase<U, Generic1>> for Image<T, Generic2>
 where
     U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<U, Generic1>) -> Self {
+    fn from(image: ImageBase<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])

--- a/src/core/colour_models.rs
+++ b/src/core/colour_models.rs
@@ -182,7 +182,7 @@ where
     (red, green, blue)
 }
 
-impl<U, T> From<Image<U, RGB>> for Image<U, HSV>
+impl<U, T> From<Image<U, RGB>> for Image<OwnedRepr<T>, HSV>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -196,7 +196,7 @@ where
         + PixelBound,
 {
     fn from(image: Image<U, RGB>) -> Self {
-        let mut res = Array3::<T>::zeros((image.rows(), image.cols(), HSV::channels()));
+        let mut res = Array3::<_>::zeros((image.rows(), image.cols(), HSV::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
         Zip::indexed(window).apply(|(i, j, _), pix| {
@@ -211,7 +211,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, HSV>> for Image<U, RGB>
+impl<T, U> From<Image<U, HSV>> for Image<OwnedRepr<T>, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -240,7 +240,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, RGB>> for Image<U, Gray>
+impl<T, U> From<Image<U, RGB>> for Image<OwnedRepr<T>, Gray>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -271,7 +271,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, Gray>> for Image<U, RGB>
+impl<T, U> From<Image<U, Gray>> for Image<OwnedRepr<T>, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -298,7 +298,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, RGB>> for Image<U, CIEXYZ>
+impl<T, U> From<Image<U, RGB>> for Image<OwnedRepr<T>, CIEXYZ>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -337,7 +337,7 @@ where
     }
 }
 
-impl<T, U> From<Image<U, CIEXYZ>> for Image<U, RGB>
+impl<T, U> From<Image<U, CIEXYZ>> for Image<OwnedRepr<T>, RGB>
 where
     U: Data<Elem = T>,
     T: Copy
@@ -376,27 +376,27 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, RGB>
+impl<S, T> From<Image<T, Generic3>> for Image<OwnedRepr<S>, RGB>
 where
-    T: Data,
+    T: Data<Elem = S>,
+{
+    fn from(image: Image<T, Generic3>) -> Self {
+        image.into_type_raw()
+    }
+}
+
+impl<S, T> From<Image<T, Generic3>> for Image<T, HSV>
+where
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, HSV>
+impl<S, T> From<Image<T, Generic3>> for Image<OwnedRepr<S>, HSI>
 where
-    T: Data,
-{
-    fn from(image: Image<T, Generic3>) -> Self {
-        Self::from_data(image.data)
-    }
-}
-
-impl<T> From<Image<T, Generic3>> for Image<T, HSI>
-where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
@@ -475,63 +475,63 @@ where
     }
 }
 
-impl<T> From<Image<T, HSV>> for Image<T, Generic3>
+impl<S, T> From<Image<T, HSV>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, HSV>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, HSI>> for Image<T, Generic3>
+impl<S, T> From<Image<T, HSI>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, HSI>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, HSL>> for Image<T, Generic3>
+impl<S, T> From<Image<T, HSL>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, HSL>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, YCrCb>> for Image<T, Generic3>
+impl<S, T> From<Image<T, YCrCb>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, YCrCb>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIEXYZ>> for Image<T, Generic3>
+impl<S, T> From<Image<T, CIEXYZ>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, CIEXYZ>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIELAB>> for Image<T, Generic3>
+impl<S, T> From<Image<T, CIELAB>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, CIELAB>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIELUV>> for Image<T, Generic3>
+impl<S, T> From<Image<T, CIELUV>> for Image<OwnedRepr<S>, Generic3>
 where
-    T: Data,
+    T: Data<Elem = S>,
 {
     fn from(image: Image<T, CIELUV>) -> Self {
         Self::from_data(image.data)

--- a/src/core/colour_models.rs
+++ b/src/core/colour_models.rs
@@ -1,6 +1,6 @@
 use crate::core::traits::*;
 use crate::core::{normalise_pixel_value, Image};
-use ndarray::{prelude::*, s, Zip};
+use ndarray::{prelude::*, s, Data, OwnedRepr, Zip};
 use num_traits::cast::{FromPrimitive, NumCast};
 use num_traits::{Num, NumAssignOps};
 use std::convert::From;
@@ -182,8 +182,9 @@ where
     (red, green, blue)
 }
 
-impl<T> From<Image<T, RGB>> for Image<T, HSV>
+impl<U, T> From<Image<U, RGB>> for Image<U, HSV>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -194,7 +195,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, RGB>) -> Self {
+    fn from(image: Image<U, RGB>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), HSV::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -210,8 +211,9 @@ where
     }
 }
 
-impl<T> From<Image<T, HSV>> for Image<T, RGB>
+impl<T, U> From<Image<U, HSV>> for Image<U, RGB>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -222,7 +224,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, HSV>) -> Self {
+    fn from(image: Image<U, HSV>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -238,8 +240,9 @@ where
     }
 }
 
-impl<T> From<Image<T, RGB>> for Image<T, Gray>
+impl<T, U> From<Image<U, RGB>> for Image<U, Gray>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -250,7 +253,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, RGB>) -> Self {
+    fn from(image: Image<U, RGB>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), Gray::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -268,8 +271,9 @@ where
     }
 }
 
-impl<T> From<Image<T, Gray>> for Image<T, RGB>
+impl<T, U> From<Image<U, Gray>> for Image<U, RGB>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -280,7 +284,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, Gray>) -> Self {
+    fn from(image: Image<U, Gray>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -294,8 +298,9 @@ where
     }
 }
 
-impl<T> From<Image<T, RGB>> for Image<T, CIEXYZ>
+impl<T, U> From<Image<U, RGB>> for Image<U, CIEXYZ>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -306,7 +311,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, RGB>) -> Self {
+    fn from(image: Image<U, RGB>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), CIEXYZ::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -332,8 +337,9 @@ where
     }
 }
 
-impl<T> From<Image<T, CIEXYZ>> for Image<T, RGB>
+impl<T, U> From<Image<U, CIEXYZ>> for Image<U, RGB>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -344,7 +350,7 @@ where
         + Display
         + PixelBound,
 {
-    fn from(image: Image<T, CIEXYZ>) -> Self {
+    fn from(image: Image<U, CIEXYZ>) -> Self {
         let mut res = Array3::<T>::zeros((image.rows(), image.cols(), RGB::channels()));
         let window = image.data.windows((1, 1, image.channels()));
 
@@ -370,241 +376,312 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, RGB> {
+impl<T> From<Image<T, Generic3>> for Image<T, RGB>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, HSV> {
+impl<T> From<Image<T, Generic3>> for Image<T, HSV>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, HSI> {
+impl<T> From<Image<T, Generic3>> for Image<T, HSI>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, HSL> {
+impl<T> From<Image<T, Generic3>> for Image<T, HSL>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, YCrCb> {
+impl<T> From<Image<T, Generic3>> for Image<T, YCrCb>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIEXYZ> {
+impl<T> From<Image<T, Generic3>> for Image<T, CIEXYZ>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIELAB> {
+impl<T> From<Image<T, Generic3>> for Image<T, CIELAB>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, CIELUV> {
+impl<T> From<Image<T, Generic3>> for Image<T, CIELUV>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic3>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Gray> {
+impl<T> From<Image<T, Generic1>> for Image<T, Gray>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic1>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, RGBA> {
+impl<T> From<Image<T, Generic4>> for Image<T, RGBA>
+where
+    T: Data,
+{
     fn from(image: Image<T, Generic4>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, RGB>> for Image<T, Generic3> {
+impl<T> From<Image<T, RGB>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, RGB>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, HSV>> for Image<T, Generic3> {
+impl<T> From<Image<T, HSV>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, HSV>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, HSI>> for Image<T, Generic3> {
+impl<T> From<Image<T, HSI>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, HSI>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, HSL>> for Image<T, Generic3> {
+impl<T> From<Image<T, HSL>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, HSL>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, YCrCb>> for Image<T, Generic3> {
+impl<T> From<Image<T, YCrCb>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, YCrCb>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIEXYZ>> for Image<T, Generic3> {
+impl<T> From<Image<T, CIEXYZ>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, CIEXYZ>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIELAB>> for Image<T, Generic3> {
+impl<T> From<Image<T, CIELAB>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, CIELAB>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, CIELUV>> for Image<T, Generic3> {
+impl<T> From<Image<T, CIELUV>> for Image<T, Generic3>
+where
+    T: Data,
+{
     fn from(image: Image<T, CIELUV>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, RGBA>> for Image<T, Generic4> {
+impl<T> From<Image<T, RGBA>> for Image<T, Generic4>
+where
+    T: Data,
+{
     fn from(image: Image<T, RGBA>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Gray>> for Image<T, Generic1> {
+impl<T> From<Image<T, Gray>> for Image<T, Generic1>
+where
+    T: Data,
+{
     fn from(image: Image<T, Gray>) -> Self {
         Self::from_data(image.data)
     }
 }
 
-impl<T> From<Image<T, Generic5>> for Image<T, Generic4>
+impl<T, U> From<Image<U, Generic5>> for Image<U, Generic4>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic5>) -> Self {
+    fn from(image: Image<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic5>> for Image<T, Generic3>
+impl<T, U> From<Image<U, Generic5>> for Image<U, Generic3>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic5>) -> Self {
+    fn from(image: Image<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic5>> for Image<T, Generic2>
+impl<T, U> From<Image<U, Generic5>> for Image<U, Generic2>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic5>) -> Self {
+    fn from(image: Image<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic5>> for Image<T, Generic1>
+impl<T, U> From<Image<U, Generic5>> for Image<U, Generic1>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic5>) -> Self {
+    fn from(image: Image<U, Generic5>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, Generic3>
+impl<T, U> From<Image<U, Generic4>> for Image<U, Generic3>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic4>) -> Self {
+    fn from(image: Image<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, Generic2>
+impl<T, U> From<Image<U, Generic4>> for Image<U, Generic2>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic4>) -> Self {
+    fn from(image: Image<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, Generic1>
+impl<T, U> From<Image<U, Generic4>> for Image<OwnedRepr<T>, Generic1>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic4>) -> Self {
+    fn from(image: Image<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, Generic2>
+impl<T, U> From<Image<U, Generic3>> for Image<OwnedRepr<T>, Generic2>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: Image<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, Generic1>
+impl<T, U> From<Image<U, Generic3>> for Image<OwnedRepr<T>, Generic1>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: Image<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic2>> for Image<T, Generic1>
+impl<T, U> From<Image<U, Generic2>> for Image<OwnedRepr<T>, Generic1>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
-    fn from(image: Image<T, Generic2>) -> Self {
+    fn from(image: Image<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic1::channels());
         let data = Array3::from_shape_fn(shape, |(i, j, k)| image.data[[i, j, k]]);
         Self::from_data(data)
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Generic5>
+impl<T, U> From<Image<U, Generic1>> for Image<OwnedRepr<T>, Generic5>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic1>) -> Self {
+    fn from(image: Image<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -613,11 +690,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic2>> for Image<T, Generic5>
+impl<T, U> From<Image<U, Generic2>> for Image<OwnedRepr<T>, Generic5>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic2>) -> Self {
+    fn from(image: Image<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -626,11 +704,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, Generic5>
+impl<T, U> From<Image<U, Generic3>> for Image<U, Generic5>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: Image<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic3::channels()])
@@ -639,11 +718,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic4>> for Image<T, Generic5>
+impl<T, U> From<Image<U, Generic4>> for Image<U, Generic5>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic4>) -> Self {
+    fn from(image: Image<U, Generic4>) -> Self {
         let shape = (image.rows(), image.cols(), Generic5::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic4::channels()])
@@ -652,11 +732,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Generic4>
+impl<T, U> From<Image<U, Generic1>> for Image<U, Generic4>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic1>) -> Self {
+    fn from(image: Image<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -665,11 +746,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic2>> for Image<T, Generic4>
+impl<T, U> From<Image<U, Generic2>> for Image<U, Generic4>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic2>) -> Self {
+    fn from(image: Image<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -678,11 +760,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic3>> for Image<T, Generic4>
+impl<T, U> From<Image<U, Generic3>> for Image<U, Generic4>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic3>) -> Self {
+    fn from(image: Image<U, Generic3>) -> Self {
         let shape = (image.rows(), image.cols(), Generic4::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic3::channels()])
@@ -691,11 +774,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Generic3>
+impl<T, U> From<Image<U, Generic1>> for Image<U, Generic3>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic1>) -> Self {
+    fn from(image: Image<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])
@@ -704,11 +788,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic2>> for Image<T, Generic3>
+impl<T, U> From<Image<U, Generic2>> for Image<U, Generic3>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic2>) -> Self {
+    fn from(image: Image<U, Generic2>) -> Self {
         let shape = (image.rows(), image.cols(), Generic3::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic2::channels()])
@@ -717,11 +802,12 @@ where
     }
 }
 
-impl<T> From<Image<T, Generic1>> for Image<T, Generic2>
+impl<T, U> From<Image<U, Generic1>> for Image<U, Generic2>
 where
+    U: Data<Elem = T>,
     T: Copy + Num,
 {
-    fn from(image: Image<T, Generic1>) -> Self {
+    fn from(image: Image<U, Generic1>) -> Self {
         let shape = (image.rows(), image.cols(), Generic2::channels());
         let mut data = Array3::zeros(shape);
         data.slice_mut(s![.., .., 0..Generic1::channels()])

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -90,13 +90,13 @@ where
     }
 }
 
-impl<T, C> Image<T, C>
+impl<T, U, C> Image<T, C>
 where
-    T: Data,
+    T: Data<Elem = U>,
     C: ColourModel,
 {
     /// Construct the image from a given Array3
-    pub fn from_data(data: Array3<T>) -> Self {
+    pub fn from_data(data: ArrayBase<T, Ix3>) -> Self {
         Image {
             data,
             model: PhantomData,
@@ -124,6 +124,15 @@ where
     /// Get a mutable view of a pixels colour channels given a location
     pub fn pixel_mut(&mut self, row: usize, col: usize) -> ArrayViewMut<T, Ix1> {
         self.data.slice_mut(s![row, col, ..])
+    }
+
+    pub fn into_type_raw<U2, C2>(self) -> Image<U2, C>
+    where
+        U2: Data<Elem = U>,
+        C2: ColourModel,
+    {
+        assert_eq!(C2::channels(), C::channels());
+        Image::<U2, C2>::from_data(self.data)
     }
 }
 

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -51,6 +51,20 @@ where
     }
 }
 
+impl<S, T, C> ImageBase<S, C>
+where
+    S: Data<Elem = T>,
+    T: Clone,
+    C: ColourModel,
+{
+    pub fn to_owned(&self) -> Image<T, C> {
+        Image {
+            data: self.data.to_owned(),
+            model: PhantomData,
+        }
+    }
+}
+
 impl<T, C> Image<T, C>
 where
     T: Clone + Num,

--- a/src/core/padding.rs
+++ b/src/core/padding.rs
@@ -1,5 +1,5 @@
 use crate::core::{ColourModel, Image};
-use ndarray::{prelude::*, s};
+use ndarray::{prelude::*, s, Data};
 use num_traits::identities::Zero;
 use std::marker::PhantomData;
 
@@ -80,8 +80,9 @@ pub trait PaddingExt {
     fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<Self::Data>) -> Self;
 }
 
-impl<T> PaddingExt for Array3<T>
+impl<T, U> PaddingExt for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy,
 {
     type Data = T;
@@ -91,8 +92,9 @@ where
     }
 }
 
-impl<T, C> PaddingExt for Image<T, C>
+impl<T, U, C> PaddingExt for Image<U, C>
 where
+    U: Data<Elem = T>,
     T: Copy,
     C: ColourModel,
 {

--- a/src/core/padding.rs
+++ b/src/core/padding.rs
@@ -1,5 +1,5 @@
-use crate::core::{ColourModel, Image};
-use ndarray::{prelude::*, s, Data};
+use crate::core::{ColourModel, Image, ImageBase};
+use ndarray::{prelude::*, s, Data, OwnedRepr};
 use num_traits::identities::Zero;
 use std::marker::PhantomData;
 
@@ -11,7 +11,11 @@ where
 {
     /// Taking in the image data and the margin to apply to rows and columns
     /// returns a padded image
-    fn pad(&self, image: ArrayView3<T>, padding: (usize, usize)) -> Array3<T>;
+    fn pad(
+        &self,
+        image: ArrayView<T, Ix3>,
+        padding: (usize, usize),
+    ) -> ArrayBase<OwnedRepr<T>, Ix3>;
 }
 
 /// Doesn't apply any padding to the image returning it unaltered regardless
@@ -33,7 +37,11 @@ impl<T> PaddingStrategy<T> for NoPadding
 where
     T: Copy,
 {
-    fn pad(&self, image: ArrayView3<T>, _padding: (usize, usize)) -> Array3<T> {
+    fn pad(
+        &self,
+        image: ArrayView<T, Ix3>,
+        _padding: (usize, usize),
+    ) -> ArrayBase<OwnedRepr<T>, Ix3> {
         image.to_owned()
     }
 }
@@ -42,7 +50,11 @@ impl<T> PaddingStrategy<T> for ConstantPadding<T>
 where
     T: Copy,
 {
-    fn pad(&self, image: ArrayView3<T>, padding: (usize, usize)) -> Array3<T> {
+    fn pad(
+        &self,
+        image: ArrayView<T, Ix3>,
+        padding: (usize, usize),
+    ) -> ArrayBase<OwnedRepr<T>, Ix3> {
         let shape = (
             image.shape()[0] + padding.0 * 2,
             image.shape()[1] + padding.1 * 2,
@@ -66,42 +78,46 @@ impl<T> PaddingStrategy<T> for ZeroPadding
 where
     T: Copy + Zero,
 {
-    fn pad(&self, image: ArrayView3<T>, padding: (usize, usize)) -> Array3<T> {
+    fn pad(
+        &self,
+        image: ArrayView<T, Ix3>,
+        padding: (usize, usize),
+    ) -> ArrayBase<OwnedRepr<T>, Ix3> {
         let padder = ConstantPadding(T::zero());
         padder.pad(image, padding)
     }
 }
 
 /// Padding extension for images
-pub trait PaddingExt {
-    /// Data type for container
-    type Data;
+pub trait PaddingExt<T> {
+    /// Type of the output image
+    type Output;
     /// Pad the object with the given padding and strategy
-    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<Self::Data>) -> Self;
+    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<T>) -> Self::Output;
 }
 
-impl<T, U> PaddingExt for ArrayBase<U, Ix3>
+impl<T, U> PaddingExt<T> for ArrayBase<U, Ix3>
 where
     U: Data<Elem = T>,
     T: Copy,
 {
-    type Data = T;
+    type Output = ArrayBase<OwnedRepr<T>, Ix3>;
 
-    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<Self::Data>) -> Self {
+    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<T>) -> Self::Output {
         strategy.pad(self.view(), padding)
     }
 }
 
-impl<T, U, C> PaddingExt for Image<U, C>
+impl<T, U, C> PaddingExt<T> for ImageBase<U, C>
 where
     U: Data<Elem = T>,
     T: Copy,
     C: ColourModel,
 {
-    type Data = T;
+    type Output = Image<T, C>;
 
-    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<Self::Data>) -> Self {
-        Self {
+    fn pad(&self, padding: (usize, usize), strategy: &dyn PaddingStrategy<T>) -> Self::Output {
+        Self::Output {
             data: strategy.pad(self.data.view(), padding),
             model: PhantomData,
         }

--- a/src/enhancement/histogram_equalisation.rs
+++ b/src/enhancement/histogram_equalisation.rs
@@ -1,5 +1,5 @@
 use crate::core::*;
-use ndarray::prelude::*;
+use ndarray::{prelude::*, Data};
 use ndarray_stats::{histogram::Grid, HistogramExt};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use num_traits::{Num, NumAssignOps};
@@ -19,8 +19,9 @@ where
     fn equalise_hist_inplace(&mut self, grid: Grid<A>);
 }
 
-impl<T> HistogramEqExt<T> for Array3<T>
+impl<T, U> HistogramEqExt<T> for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
 {
     fn equalise_hist(&self, grid: Grid<T>) -> Self {
@@ -71,9 +72,10 @@ where
     }
 }
 
-impl<T, C> HistogramEqExt<T> for Image<T, C>
+impl<T, U, C> HistogramEqExt<T> for Image<U, C>
 where
-    Image<T, C>: Clone,
+    U: Data<Elem = T>,
+    Image<U, C>: Clone,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {

--- a/src/enhancement/histogram_equalisation.rs
+++ b/src/enhancement/histogram_equalisation.rs
@@ -1,5 +1,5 @@
 use crate::core::*;
-use ndarray::{prelude::*, Data, DataMut};
+use ndarray::{prelude::*, DataMut};
 use ndarray_stats::{histogram::Grid, HistogramExt};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use num_traits::{Num, NumAssignOps};
@@ -22,7 +22,7 @@ where
 
 impl<T, U> HistogramEqExt<T> for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
 {
     type Output = Array<T, Ix3>;
@@ -77,7 +77,7 @@ where
 
 impl<T, U, C> HistogramEqExt<T> for ImageBase<U, C>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {

--- a/src/enhancement/histogram_equalisation.rs
+++ b/src/enhancement/histogram_equalisation.rs
@@ -1,5 +1,5 @@
 use crate::core::*;
-use ndarray::{prelude::*, Data};
+use ndarray::{prelude::*, Data, DataMut};
 use ndarray_stats::{histogram::Grid, HistogramExt};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use num_traits::{Num, NumAssignOps};
@@ -21,7 +21,7 @@ where
 
 impl<T, U> HistogramEqExt<T> for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T>,
+    U: Data<Elem = T> + DataMut<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
 {
     fn equalise_hist(&self, grid: Grid<T>) -> Self {

--- a/src/enhancement/histogram_equalisation.rs
+++ b/src/enhancement/histogram_equalisation.rs
@@ -10,9 +10,10 @@ pub trait HistogramEqExt<A>
 where
     A: Ord,
 {
+    type Output;
     /// Equalises an image histogram returning a new image.
     /// Grids should be for a 1xN image as the image is flattened during processing
-    fn equalise_hist(&self, grid: Grid<A>) -> Self;
+    fn equalise_hist(&self, grid: Grid<A>) -> Self::Output;
 
     /// Equalises an image histogram inplace
     /// Grids should be for a 1xN image as the image is flattened during processing
@@ -24,8 +25,10 @@ where
     U: Data<Elem = T> + DataMut<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
 {
-    fn equalise_hist(&self, grid: Grid<T>) -> Self {
-        let mut result = self.clone();
+    type Output = Array<T, Ix3>;
+
+    fn equalise_hist(&self, grid: Grid<T>) -> Self::Output {
+        let mut result = self.to_owned();
         result.equalise_hist_inplace(grid);
         result
     }
@@ -72,15 +75,16 @@ where
     }
 }
 
-impl<T, U, C> HistogramEqExt<T> for Image<U, C>
+impl<T, U, C> HistogramEqExt<T> for ImageBase<U, C>
 where
-    U: Data<Elem = T>,
-    Image<U, C>: Clone,
+    U: Data<Elem = T> + DataMut<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {
-    fn equalise_hist(&self, grid: Grid<T>) -> Self {
-        let mut result = self.clone();
+    type Output = Image<T, C>;
+
+    fn equalise_hist(&self, grid: Grid<T>) -> Self::Output {
+        let mut result = self.to_owned();
         result.equalise_hist_inplace(grid);
         result
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -16,11 +16,15 @@ where
     C: ColourModel,
 {
     /// Encode an image into a sequence of bytes for the given format
-    fn encode(&self, image: &Image<U, C>) -> Vec<u8>;
+    fn encode(&self, image: &ImageBase<U, C>) -> Vec<u8>;
 
     /// Encode an image saving it to the file at filename. This function shouldn't
     /// add an extension preferring the user to do that instead.
-    fn encode_file<P: AsRef<Path>>(&self, image: &Image<U, C>, filename: P) -> std::io::Result<()> {
+    fn encode_file<P: AsRef<Path>>(
+        &self,
+        image: &ImageBase<U, C>,
+        filename: P,
+    ) -> std::io::Result<()> {
         let mut file = File::create(filename)?;
         file.write_all(&self.encode(image))?;
         Ok(())
@@ -30,7 +34,6 @@ where
 /// Trait for an image decoder, use this to get an image from a byte stream
 pub trait Decoder<T, U, C>
 where
-    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -44,9 +47,9 @@ where
 {
     /// From the bytes decode an image, will perform any scaling or conversions
     /// required to represent elements with type T.
-    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<U, C>>;
+    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<T, C>>;
     /// Given a filename decode an image performing any necessary conversions.
-    fn decode_file<P: AsRef<Path>>(&self, filename: P) -> std::io::Result<Image<U, C>> {
+    fn decode_file<P: AsRef<Path>>(&self, filename: P) -> std::io::Result<Image<T, C>> {
         let bytes = read(filename)?;
         self.decode(&bytes)
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -32,7 +32,7 @@ where
 }
 
 /// Trait for an image decoder, use this to get an image from a byte stream
-pub trait Decoder<T, U, C>
+pub trait Decoder<T, C>
 where
     T: Copy
         + Clone

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,5 +1,6 @@
 use crate::core::traits::PixelBound;
 use crate::core::*;
+use ndarray::Data;
 use num_traits::cast::{FromPrimitive, NumCast};
 use num_traits::{Num, NumAssignOps};
 use std::fmt::Display;
@@ -8,17 +9,18 @@ use std::io::prelude::*;
 use std::path::Path;
 
 /// Trait for an image encoder
-pub trait Encoder<T, C>
+pub trait Encoder<T, U, C>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
     C: ColourModel,
 {
     /// Encode an image into a sequence of bytes for the given format
-    fn encode(&self, image: &Image<T, C>) -> Vec<u8>;
+    fn encode(&self, image: &Image<U, C>) -> Vec<u8>;
 
     /// Encode an image saving it to the file at filename. This function shouldn't
     /// add an extension preferring the user to do that instead.
-    fn encode_file<P: AsRef<Path>>(&self, image: &Image<T, C>, filename: P) -> std::io::Result<()> {
+    fn encode_file<P: AsRef<Path>>(&self, image: &Image<U, C>, filename: P) -> std::io::Result<()> {
         let mut file = File::create(filename)?;
         file.write_all(&self.encode(image))?;
         Ok(())
@@ -26,8 +28,9 @@ where
 }
 
 /// Trait for an image decoder, use this to get an image from a byte stream
-pub trait Decoder<T, C>
+pub trait Decoder<T, U, C>
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + FromPrimitive
@@ -41,9 +44,9 @@ where
 {
     /// From the bytes decode an image, will perform any scaling or conversions
     /// required to represent elements with type T.
-    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<T, C>>;
+    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<U, C>>;
     /// Given a filename decode an image performing any necessary conversions.
-    fn decode_file<P: AsRef<Path>>(&self, filename: P) -> std::io::Result<Image<T, C>> {
+    fn decode_file<P: AsRef<Path>>(&self, filename: P) -> std::io::Result<Image<U, C>> {
         let bytes = read(filename)?;
         self.decode(&bytes)
     }

--- a/src/format/netpbm.rs
+++ b/src/format/netpbm.rs
@@ -1,4 +1,4 @@
-use crate::core::{normalise_pixel_value, Image, PixelBound, RGB};
+use crate::core::{normalise_pixel_value, Image, ImageBase, PixelBound, RGB};
 use crate::format::{Decoder, Encoder};
 use ndarray::Data;
 use num_traits::cast::{FromPrimitive, NumCast};
@@ -46,7 +46,7 @@ where
         + PixelBound
         + FromPrimitive,
 {
-    fn encode(&self, image: &Image<U, RGB>) -> Vec<u8> {
+    fn encode(&self, image: &ImageBase<U, RGB>) -> Vec<u8> {
         use EncodingType::*;
         match self.encoding {
             Plaintext => self.encode_plaintext(image),
@@ -73,7 +73,7 @@ impl PpmEncoder {
 
     /// Gets the maximum pixel value in the image across all channels. This is
     /// used in the PPM header
-    fn get_max_value<T, U>(image: &Image<U, RGB>) -> Option<u8>
+    fn get_max_value<T, U>(image: &ImageBase<U, RGB>) -> Option<u8>
     where
         U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
@@ -95,7 +95,7 @@ impl PpmEncoder {
     }
 
     /// Encode the image into the binary PPM format (P6) returning the bytes
-    fn encode_binary<T, U>(self, image: &Image<U, RGB>) -> Vec<u8>
+    fn encode_binary<T, U>(self, image: &ImageBase<U, RGB>) -> Vec<u8>
     where
         U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
@@ -117,7 +117,7 @@ impl PpmEncoder {
 
     /// Encode the image into the plaintext PPM format (P3) returning the text as
     /// an array of bytes
-    fn encode_plaintext<T, U>(self, image: &Image<U, RGB>) -> Vec<u8>
+    fn encode_plaintext<T, U>(self, image: &ImageBase<U, RGB>) -> Vec<u8>
     where
         U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
@@ -168,7 +168,7 @@ where
         + PixelBound
         + FromPrimitive,
 {
-    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<U, RGB>> {
+    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<T, RGB>> {
         if bytes.len() < 9 {
             Err(Error::new(
                 ErrorKind::InvalidData,
@@ -226,9 +226,8 @@ impl PpmDecoder {
         }
     }
 
-    fn decode_binary<T, U>(bytes: &[u8]) -> std::io::Result<Image<U, RGB>>
+    fn decode_binary<T>(bytes: &[u8]) -> std::io::Result<Image<T, RGB>>
     where
-        U: Data<Elem = T>,
         T: Copy
             + Clone
             + Num
@@ -280,9 +279,8 @@ impl PpmDecoder {
         }
     }
 
-    fn decode_plaintext<T, U>(bytes: &[u8]) -> std::io::Result<Image<U, RGB>>
+    fn decode_plaintext<T>(bytes: &[u8]) -> std::io::Result<Image<T, RGB>>
     where
-        U: Data<Elem = T>,
         T: Copy
             + Clone
             + Num

--- a/src/format/netpbm.rs
+++ b/src/format/netpbm.rs
@@ -155,9 +155,8 @@ impl PpmEncoder {
 /// The ColourModel type argument is locked to RGB - this prevents calling
 /// RGB::into::<RGB>() unnecessarily which is unavoidable until trait specialisation is
 /// stabilised.
-impl<T, U> Decoder<T, U, RGB> for PpmDecoder
+impl<T> Decoder<T, RGB> for PpmDecoder
 where
-    U: Data<Elem = T>,
     T: Copy
         + Clone
         + Num

--- a/src/format/netpbm.rs
+++ b/src/format/netpbm.rs
@@ -1,5 +1,6 @@
 use crate::core::{normalise_pixel_value, Image, PixelBound, RGB};
 use crate::format::{Decoder, Encoder};
+use ndarray::Data;
 use num_traits::cast::{FromPrimitive, NumCast};
 use num_traits::{Num, NumAssignOps};
 use std::fmt::Display;
@@ -32,8 +33,9 @@ impl Default for PpmEncoder {
 /// The ColourModel type argument is locked to RGB - this prevents calling
 /// RGB::into::<RGB>() unnecessarily which is unavoidable until trait specialisation is
 /// stabilised.
-impl<T> Encoder<T, RGB> for PpmEncoder
+impl<T, U> Encoder<T, U, RGB> for PpmEncoder
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + Num
@@ -44,7 +46,7 @@ where
         + PixelBound
         + FromPrimitive,
 {
-    fn encode(&self, image: &Image<T, RGB>) -> Vec<u8> {
+    fn encode(&self, image: &Image<U, RGB>) -> Vec<u8> {
         use EncodingType::*;
         match self.encoding {
             Plaintext => self.encode_plaintext(image),
@@ -71,8 +73,9 @@ impl PpmEncoder {
 
     /// Gets the maximum pixel value in the image across all channels. This is
     /// used in the PPM header
-    fn get_max_value<T>(image: &Image<T, RGB>) -> Option<u8>
+    fn get_max_value<T, U>(image: &Image<U, RGB>) -> Option<u8>
     where
+        U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
     {
         image
@@ -92,8 +95,9 @@ impl PpmEncoder {
     }
 
     /// Encode the image into the binary PPM format (P6) returning the bytes
-    fn encode_binary<T>(self, image: &Image<T, RGB>) -> Vec<u8>
+    fn encode_binary<T, U>(self, image: &Image<U, RGB>) -> Vec<u8>
     where
+        U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
     {
         let max_val = Self::get_max_value(image).unwrap_or_else(|| 255);
@@ -113,8 +117,9 @@ impl PpmEncoder {
 
     /// Encode the image into the plaintext PPM format (P3) returning the text as
     /// an array of bytes
-    fn encode_plaintext<T>(self, image: &Image<T, RGB>) -> Vec<u8>
+    fn encode_plaintext<T, U>(self, image: &Image<U, RGB>) -> Vec<u8>
     where
+        U: Data<Elem = T>,
         T: Copy + Clone + Num + NumAssignOps + NumCast + PartialOrd + Display + PixelBound,
     {
         let max_val = 255;
@@ -150,8 +155,9 @@ impl PpmEncoder {
 /// The ColourModel type argument is locked to RGB - this prevents calling
 /// RGB::into::<RGB>() unnecessarily which is unavoidable until trait specialisation is
 /// stabilised.
-impl<T> Decoder<T, RGB> for PpmDecoder
+impl<T, U> Decoder<T, U, RGB> for PpmDecoder
 where
+    U: Data<Elem = T>,
     T: Copy
         + Clone
         + Num
@@ -162,7 +168,7 @@ where
         + PixelBound
         + FromPrimitive,
 {
-    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<T, RGB>> {
+    fn decode(&self, bytes: &[u8]) -> std::io::Result<Image<U, RGB>> {
         if bytes.len() < 9 {
             Err(Error::new(
                 ErrorKind::InvalidData,
@@ -220,8 +226,9 @@ impl PpmDecoder {
         }
     }
 
-    fn decode_binary<T>(bytes: &[u8]) -> std::io::Result<Image<T, RGB>>
+    fn decode_binary<T, U>(bytes: &[u8]) -> std::io::Result<Image<U, RGB>>
     where
+        U: Data<Elem = T>,
         T: Copy
             + Clone
             + Num
@@ -273,8 +280,9 @@ impl PpmDecoder {
         }
     }
 
-    fn decode_plaintext<T>(bytes: &[u8]) -> std::io::Result<Image<T, RGB>>
+    fn decode_plaintext<T, U>(bytes: &[u8]) -> std::io::Result<Image<U, RGB>>
     where
+        U: Data<Elem = T>,
         T: Copy
             + Clone
             + Num

--- a/src/processing/canny.rs
+++ b/src/processing/canny.rs
@@ -1,7 +1,7 @@
 use crate::core::{ColourModel, Image, ImageBase};
 use crate::processing::*;
 use ndarray::prelude::*;
-use ndarray::{Data, DataMut, IntoDimension};
+use ndarray::{DataMut, IntoDimension};
 use num_traits::{cast::FromPrimitive, real::Real, Num, NumAssignOps};
 use std::collections::HashSet;
 use std::marker::PhantomData;
@@ -40,7 +40,7 @@ pub struct CannyParameters<T> {
 
 impl<T, U, C> CannyEdgeDetectorExt<T> for ImageBase<U, C>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
     C: ColourModel,
 {
@@ -57,7 +57,7 @@ where
 
 impl<T, U> CannyEdgeDetectorExt<T> for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
 {
     type Output = Array3<bool>;

--- a/src/processing/canny.rs
+++ b/src/processing/canny.rs
@@ -1,7 +1,7 @@
 use crate::core::{ColourModel, Image};
 use crate::processing::*;
 use ndarray::prelude::*;
-use ndarray::IntoDimension;
+use ndarray::{Data, IntoDimension, OwnedRepr};
 use num_traits::{cast::FromPrimitive, real::Real, Num, NumAssignOps};
 use std::collections::HashSet;
 use std::marker::PhantomData;
@@ -38,12 +38,13 @@ pub struct CannyParameters<T> {
     pub t2: T,
 }
 
-impl<T, C> CannyEdgeDetectorExt<T> for Image<T, C>
+impl<T, U, C> CannyEdgeDetectorExt<T> for Image<U, C>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
     C: ColourModel,
 {
-    type Output = Image<bool, C>;
+    type Output = Image<OwnedRepr<bool>, C>;
 
     fn canny_edge_detector(&self, params: CannyParameters<T>) -> Result<Self::Output, Error> {
         let data = self.data.canny_edge_detector(params)?;
@@ -54,8 +55,9 @@ where
     }
 }
 
-impl<T> CannyEdgeDetectorExt<T> for Array3<T>
+impl<T, U> CannyEdgeDetectorExt<T> for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
 {
     type Output = Array3<bool>;

--- a/src/processing/canny.rs
+++ b/src/processing/canny.rs
@@ -1,7 +1,7 @@
-use crate::core::{ColourModel, Image};
+use crate::core::{ColourModel, Image, ImageBase};
 use crate::processing::*;
 use ndarray::prelude::*;
-use ndarray::{Data, IntoDimension, OwnedRepr};
+use ndarray::{Data, DataMut, IntoDimension};
 use num_traits::{cast::FromPrimitive, real::Real, Num, NumAssignOps};
 use std::collections::HashSet;
 use std::marker::PhantomData;
@@ -38,13 +38,13 @@ pub struct CannyParameters<T> {
     pub t2: T,
 }
 
-impl<T, U, C> CannyEdgeDetectorExt<T> for Image<U, C>
+impl<T, U, C> CannyEdgeDetectorExt<T> for ImageBase<U, C>
 where
-    U: Data<Elem = T>,
+    U: Data<Elem = T> + DataMut<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
     C: ColourModel,
 {
-    type Output = Image<OwnedRepr<bool>, C>;
+    type Output = Image<bool, C>;
 
     fn canny_edge_detector(&self, params: CannyParameters<T>) -> Result<Self::Output, Error> {
         let data = self.data.canny_edge_detector(params)?;
@@ -57,7 +57,7 @@ where
 
 impl<T, U> CannyEdgeDetectorExt<T> for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T>,
+    U: Data<Elem = T> + DataMut<Elem = T>,
     T: Copy + Clone + FromPrimitive + Real + Num + NumAssignOps,
 {
     type Output = Array3<bool>;

--- a/src/processing/conv.rs
+++ b/src/processing/conv.rs
@@ -2,7 +2,7 @@ use crate::core::padding::*;
 use crate::core::{ColourModel, Image, ImageBase};
 use crate::processing::Error;
 use ndarray::prelude::*;
-use ndarray::{s, Data, DataMut, Zip};
+use ndarray::{s, DataMut, Zip};
 use num_traits::{Num, NumAssignOps};
 use std::marker::PhantomData;
 use std::marker::Sized;
@@ -47,7 +47,7 @@ fn kernel_centre(rows: usize, cols: usize) -> (usize, usize) {
 
 impl<T, U> ConvolutionExt for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps,
 {
     type Data = T;
@@ -104,7 +104,7 @@ where
 
 impl<T, U, C> ConvolutionExt for ImageBase<U, C>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps,
     C: ColourModel,
 {

--- a/src/processing/conv.rs
+++ b/src/processing/conv.rs
@@ -111,7 +111,7 @@ where
     type Data = T;
     type Output = Image<OwnedRepr<T>, C>;
 
-    fn conv2d(&self, kernel: ArrayView3<Self::Data>) -> Result<Self, Error> {
+    fn conv2d(&self, kernel: ArrayView3<Self::Data>) -> Result<Self::Output, Error> {
         let data = self.data.conv2d(kernel)?;
         Ok(Self {
             data,

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -1,4 +1,4 @@
-use crate::core::{ColourModel, Image};
+use crate::core::{ColourModel, Image, ImageBase};
 use ndarray::prelude::*;
 use ndarray::{Data, IntoDimension, OwnedRepr, Zip};
 use ndarray_stats::interpolate::*;
@@ -47,13 +47,13 @@ where
     }
 }
 
-impl<T, U, C> MedianFilterExt for Image<U, C>
+impl<T, U, C> MedianFilterExt for ImageBase<U, C>
 where
     U: Data<Elem = T>,
     T: Copy + Clone + FromPrimitive + ToPrimitive + Num + Ord,
     C: ColourModel,
 {
-    type Output = Image<OwnedRepr<T>, C>;
+    type Output = Image<T, C>;
 
     fn median_filter<E>(&self, region: E) -> Self::Output
     where

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -1,6 +1,6 @@
 use crate::core::{ColourModel, Image};
 use ndarray::prelude::*;
-use ndarray::{IntoDimension, Zip};
+use ndarray::{Data, IntoDimension, OwnedRepr, Zip};
 use ndarray_stats::interpolate::*;
 use ndarray_stats::Quantile1dExt;
 use noisy_float::types::n64;
@@ -11,18 +11,22 @@ use std::marker::PhantomData;
 /// Median filter, given a region to move over the image, each pixel is given
 /// the median value of itself and it's neighbours
 pub trait MedianFilterExt {
+    type Output;
     /// Run the median filter given the region. Median is assumed to be calculated
     /// independently for each channel.
-    fn median_filter<E>(&self, region: E) -> Self
+    fn median_filter<E>(&self, region: E) -> Self::Output
     where
         E: IntoDimension<Dim = Ix2>;
 }
 
-impl<T> MedianFilterExt for Array3<T>
+impl<T, U> MedianFilterExt for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + FromPrimitive + ToPrimitive + Num + Ord,
 {
-    fn median_filter<E>(&self, region: E) -> Self
+    type Output = ArrayBase<OwnedRepr<T>, Ix3>;
+
+    fn median_filter<E>(&self, region: E) -> Self::Output
     where
         E: IntoDimension<Dim = Ix2>,
     {
@@ -43,12 +47,15 @@ where
     }
 }
 
-impl<T, C> MedianFilterExt for Image<T, C>
+impl<T, U, C> MedianFilterExt for Image<U, C>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + FromPrimitive + ToPrimitive + Num + Ord,
     C: ColourModel,
 {
-    fn median_filter<E>(&self, region: E) -> Self
+    type Output = Image<OwnedRepr<T>, C>;
+
+    fn median_filter<E>(&self, region: E) -> Self::Output
     where
         E: IntoDimension<Dim = Ix2>,
     {

--- a/src/processing/kernels.rs
+++ b/src/processing/kernels.rs
@@ -44,7 +44,7 @@ pub struct LaplaceFilter;
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub enum LaplaceType {
     /// Standard filter and the default parameter choice, for a 3x3x1 matrix it is:
-    /// ```ignore
+    /// ```text
     /// [0, -1, 0]
     /// [-1, 4, -1]
     /// [0, -1, 0]
@@ -52,7 +52,7 @@ pub enum LaplaceType {
     Standard,
     /// The diagonal filter also contains derivatives for diagonal lines and
     /// for a 3x3x1 matrix is given by:
-    /// ```ignore
+    /// ```text
     /// [-1, -1, -1]
     /// [-1, 8, -1]
     /// [-1, -1, -1]
@@ -102,7 +102,7 @@ where
 {
     /// The parameter for the Gaussian filter is the horizontal and vertical
     /// covariances to form the covariance matrix.
-    /// ```ignore
+    /// ```text
     /// [ Params[0], 0]
     /// [ 0, Params[1]]
     /// ```

--- a/src/processing/sobel.rs
+++ b/src/processing/sobel.rs
@@ -46,8 +46,9 @@ where
     Ok((h_deriv, v_deriv))
 }
 
-impl<T> SobelExt for Array3<T>
+impl<T, U> SobelExt for ArrayBase<U, Ix3>
 where
+    U: Data<Elem=T>,
     T: Copy + Clone + Num + NumAssignOps + Neg<Output = T> + FromPrimitive + Real,
 {
     type Output = ArrayBase<OwnedRepr<T>, Ix3>;
@@ -68,10 +69,13 @@ where
     }
 }
 
-impl<T> FullSobelExt for Array3<T>
+impl<T, U> FullSobelExt for ArrayBase<U, Ix3>
 where
+    U: Data<Elem=T>,
     T: Copy + Clone + Num + NumAssignOps + Neg<Output = T> + FromPrimitive + Real,
 {
+    type Output = ArrayBase<OwnedRepr<T>, Ix3>;
+
     fn full_sobel(&self) -> Result<(Self::Output, Self::Output), Error> {
         let (h_deriv, v_deriv) = get_edge_images(self)?;
 

--- a/src/processing/sobel.rs
+++ b/src/processing/sobel.rs
@@ -1,7 +1,7 @@
 use crate::core::*;
 use crate::processing::*;
 use core::ops::Neg;
-use ndarray::{prelude::*, Data, DataMut, OwnedRepr};
+use ndarray::{prelude::*, DataMut, OwnedRepr};
 use num_traits::{cast::FromPrimitive, real::Real, Num, NumAssignOps};
 use std::marker::Sized;
 
@@ -20,11 +20,9 @@ where
     fn full_sobel(&self) -> Result<(Self::Output, Self::Output), Error>;
 }
 
-fn get_edge_images<T, U>(
-    mat: &ArrayBase<U, Ix3>,
-) -> Result<(ArrayBase<OwnedRepr<T>, Ix3>, ArrayBase<OwnedRepr<T>, Ix3>), Error>
+fn get_edge_images<T, U>(mat: &ArrayBase<U, Ix3>) -> Result<(Array3<T>, Array3<T>), Error>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + Neg<Output = T> + FromPrimitive + Real,
 {
     let v_temp: Array3<T> = SobelFilter::build_with_params(Orientation::Vertical).unwrap();
@@ -41,7 +39,7 @@ where
 
 impl<T, U> SobelExt for ArrayBase<U, Ix3>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + Neg<Output = T> + FromPrimitive + Real,
 {
     type Output = ArrayBase<OwnedRepr<T>, Ix3>;
@@ -77,7 +75,7 @@ where
 
 impl<T, U, C> SobelExt for ImageBase<U, C>
 where
-    U: Data<Elem = T> + DataMut<Elem = T>,
+    U: DataMut<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + Neg<Output = T> + FromPrimitive + Real,
     C: ColourModel,
 {

--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -1,7 +1,7 @@
 use crate::core::PixelBound;
 use crate::core::{ColourModel, Image};
 use crate::processing::*;
-use ndarray::prelude::*;
+use ndarray::{prelude::*, Data, OwnedRepr};
 use ndarray_stats::histogram::{Bins, Edges, Grid};
 use ndarray_stats::HistogramExt;
 use ndarray_stats::QuantileExt;
@@ -41,13 +41,14 @@ pub trait ThresholdMeanExt<T> {
     fn threshold_mean(&self) -> Result<Self::Output, Error>;
 }
 
-impl<T, C> ThresholdOtsuExt<T> for Image<T, C>
+impl<T, U, C> ThresholdOtsuExt<T> for Image<U, C>
 where
-    Image<T, C>: Clone,
+    U: Data<Elem = T>,
+    Image<U, C>: Clone,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {
-    type Output = Image<bool, C>;
+    type Output = Image<OwnedRepr<bool>, C>;
 
     fn threshold_otsu(&self) -> Result<Self::Output, Error> {
         let data = self.data.threshold_otsu()?;
@@ -58,8 +59,9 @@ where
     }
 }
 
-impl<T> ThresholdOtsuExt<T> for Array3<T>
+impl<T, U> ThresholdOtsuExt<T> for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive,
 {
     type Output = Array3<bool>;
@@ -68,7 +70,7 @@ where
         if self.shape()[2] > 1 {
             Err(Error::ChannelDimensionMismatch)
         } else {
-            let value = calculate_threshold_otsu(&self)?;
+            let value = calculate_threshold_otsu(self)?;
             let mask = apply_threshold(self, value);
             Ok(mask)
         }
@@ -82,8 +84,9 @@ where
 /// i.e. single channel; otherwise we need to output all 3 threshold values).
 /// Todo: Add optional nbins
 ///
-fn calculate_threshold_otsu<T>(mat: &Array3<T>) -> Result<f64, Error>
+fn calculate_threshold_otsu<T, U>(mat: &ArrayBase<U, Ix3>) -> Result<f64, Error>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive,
 {
     let mut threshold = 0.0;
@@ -132,13 +135,14 @@ where
     Ok(threshold)
 }
 
-impl<T, C> ThresholdMeanExt<T> for Image<T, C>
+impl<T, U, C> ThresholdMeanExt<T> for Image<U, C>
 where
-    Image<T, C>: Clone,
+    U: Data<Elem = T>,
+    Image<U, C>: Clone,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {
-    type Output = Image<bool, C>;
+    type Output = Image<OwnedRepr<bool>, C>;
 
     fn threshold_mean(&self) -> Result<Self::Output, Error> {
         let data = self.data.threshold_mean()?;
@@ -149,8 +153,9 @@ where
     }
 }
 
-impl<T> ThresholdMeanExt<T> for Array3<T>
+impl<T, U> ThresholdMeanExt<T> for ArrayBase<U, Ix3>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive,
 {
     type Output = Array3<bool>;
@@ -159,22 +164,24 @@ where
         if self.shape()[2] > 1 {
             Err(Error::ChannelDimensionMismatch)
         } else {
-            let value = calculate_threshold_mean(&self)?;
+            let value = calculate_threshold_mean(self)?;
             let mask = apply_threshold(self, value);
             Ok(mask)
         }
     }
 }
 
-fn calculate_threshold_mean<T>(array: &Array3<T>) -> Result<f64, Error>
+fn calculate_threshold_mean<T, U>(array: &ArrayBase<U, Ix3>) -> Result<f64, Error>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + ToPrimitive + FromPrimitive,
 {
     Ok(array.sum().to_f64().unwrap() / array.len() as f64)
 }
 
-fn apply_threshold<T>(data: &Array3<T>, threshold: f64) -> Array3<bool>
+fn apply_threshold<T, U>(data: &ArrayBase<U, Ix3>, threshold: f64) -> Array3<bool>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps + ToPrimitive + FromPrimitive,
 {
     let result = data.mapv(|x| x.to_f64().unwrap() >= threshold);

--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -1,7 +1,7 @@
 use crate::core::PixelBound;
-use crate::core::{ColourModel, Image};
+use crate::core::{ColourModel, Image, ImageBase};
 use crate::processing::*;
-use ndarray::{prelude::*, Data, OwnedRepr};
+use ndarray::{prelude::*, Data};
 use ndarray_stats::histogram::{Bins, Edges, Grid};
 use ndarray_stats::HistogramExt;
 use ndarray_stats::QuantileExt;
@@ -41,14 +41,14 @@ pub trait ThresholdMeanExt<T> {
     fn threshold_mean(&self) -> Result<Self::Output, Error>;
 }
 
-impl<T, U, C> ThresholdOtsuExt<T> for Image<U, C>
+impl<T, U, C> ThresholdOtsuExt<T> for ImageBase<U, C>
 where
     U: Data<Elem = T>,
     Image<U, C>: Clone,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {
-    type Output = Image<OwnedRepr<bool>, C>;
+    type Output = Image<bool, C>;
 
     fn threshold_otsu(&self) -> Result<Self::Output, Error> {
         let data = self.data.threshold_otsu()?;
@@ -135,14 +135,14 @@ where
     Ok(threshold)
 }
 
-impl<T, U, C> ThresholdMeanExt<T> for Image<U, C>
+impl<T, U, C> ThresholdMeanExt<T> for ImageBase<U, C>
 where
     U: Data<Elem = T>,
     Image<U, C>: Clone,
     T: Copy + Clone + Ord + Num + NumAssignOps + ToPrimitive + FromPrimitive + PixelBound,
     C: ColourModel,
 {
-    type Output = Image<OwnedRepr<bool>, C>;
+    type Output = Image<bool, C>;
 
     fn threshold_mean(&self) -> Result<Self::Output, Error> {
         let data = self.data.threshold_mean()?;

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,6 +1,6 @@
-use crate::core::{ColourModel, Image};
+use crate::core::{ColourModel, Image, ImageBase};
 use crate::transform::affine::translation;
-use ndarray::{array, prelude::*, s, Data, OwnedRepr};
+use ndarray::{array, prelude::*, s, Data};
 use ndarray_linalg::solve::Inverse;
 use num_traits::{Num, NumAssignOps};
 use std::cmp::{max, min};
@@ -87,7 +87,7 @@ where
     T: Copy + Clone + Num + NumAssignOps,
     U: Data<Elem = T>,
 {
-    type Output = ArrayBase<OwnedRepr<T>, Ix3>;
+    type Output = Array<T, Ix3>;
 
     fn transform(
         &self,
@@ -138,13 +138,13 @@ where
     }
 }
 
-impl<T, U, C> TransformExt for Image<U, C>
+impl<T, U, C> TransformExt for ImageBase<U, C>
 where
     U: Data<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps,
     C: ColourModel,
 {
-    type Output = Image<OwnedRepr<T>, C>;
+    type Output = Image<T, C>;
 
     fn transform(
         &self,
@@ -152,7 +152,8 @@ where
         output_size: Option<(usize, usize)>,
     ) -> Result<Self::Output, Error> {
         let data = self.data.transform(transform, output_size)?;
-        Ok(Self::from_array(data))
+        let result = Self::Output::from_array(data).to_owned();
+        Ok(result)
     }
 }
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -4,7 +4,6 @@ use ndarray::{array, prelude::*, s, Data, OwnedRepr};
 use ndarray_linalg::solve::Inverse;
 use num_traits::{Num, NumAssignOps};
 use std::cmp::{max, min};
-use std::marker::PhantomData;
 
 pub mod affine;
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,6 +1,6 @@
 use crate::core::{ColourModel, Image};
 use crate::transform::affine::translation;
-use ndarray::{array, prelude::*, s, Data};
+use ndarray::{array, prelude::*, s, Data, OwnedRepr};
 use ndarray_linalg::solve::Inverse;
 use num_traits::{Num, NumAssignOps};
 use std::cmp::{max, min};
@@ -88,7 +88,7 @@ where
     T: Copy + Clone + Num + NumAssignOps,
     U: Data<Elem = T>,
 {
-    type Output = Array3<T>;
+    type Output = ArrayBase<OwnedRepr<T>, Ix3>;
 
     fn transform(
         &self,
@@ -139,12 +139,13 @@ where
     }
 }
 
-impl<T, C> TransformExt for Image<T, C>
+impl<T, U, C> TransformExt for Image<U, C>
 where
+    U: Data<Elem = T>,
     T: Copy + Clone + Num + NumAssignOps,
     C: ColourModel,
 {
-    type Output = Self;
+    type Output = Image<OwnedRepr<T>, C>;
 
     fn transform(
         &self,
@@ -152,10 +153,7 @@ where
         output_size: Option<(usize, usize)>,
     ) -> Result<Self::Output, Error> {
         let data = self.data.transform(transform, output_size)?;
-        Ok(Self {
-            data,
-            model: PhantomData,
-        })
+        Ok(Self::from_array(data))
     }
 }
 


### PR DESCRIPTION
Rename the `Image` type to `ImageBase` and have it take `T: Data` and use `ArrayBase<T, Ix3>` as the underlying data type instead of `Array3<T>`.

Type alias `type Image = ImageBase<OwnedRepr<T>, _>` created to replicate old behaviour. Examples and tests mostly unchanged so this shouldn't affect existing users (although they should be able to improve their code easily now)