### PR TITLE
fix some ndarray bounds, lapacke via mkl in dev, and category slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,20 @@ repository = "https://github.com/xd009642/ndarray-vision"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 keywords = ["image", "vision", "image-processing"]
-categories = ["Science", "Multimedia"]
+categories = ["science", "science::robotics", "multimedia", "multimedia::images", "graphics"]
 edition = "2018"
 
 [dependencies]
-ndarray = "0.13"
-ndarray-stats = "0.3"
-ndarray-linalg = "0.12"
-noisy_float = "0.1"
-num-traits = "0.2"
+ndarray = { version = "0.13", default-features = false }
+ndarray-stats = { version = "0.3", default-features = false }
+ndarray-linalg = { version = "0.12", default-features = false }
+noisy_float = { version = "0.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 ndarray-rand = "0.11.0"
 rand = "0.7"
 assert_approx_eq = "1.1.0"
 noisy_float = "0.1.11"
-openblas-src = "0.7"
 png = "0.15"
+ndarray-linalg = { version = "0.12", features = ["intel-mkl"] }

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,5 +1,3 @@
-extern crate openblas_src;
-
 use ndarray_vision::core::*;
 use ndarray_vision::format::netpbm::*;
 use ndarray_vision::format::*;

--- a/src/processing/conv.rs
+++ b/src/processing/conv.rs
@@ -2,7 +2,7 @@ use crate::core::padding::*;
 use crate::core::{kernel_centre, ColourModel, Image, ImageBase};
 use crate::processing::Error;
 use ndarray::prelude::*;
-use ndarray::{s, DataMut, Zip};
+use ndarray::{s, DataMut, Data, Zip};
 use num_traits::{Num, NumAssignOps};
 use std::marker::PhantomData;
 use std::marker::Sized;
@@ -19,22 +19,22 @@ where
 
     /// Perform a convolution returning the resultant data
     /// applies the default padding of zero padding
-    fn conv2d(&self, kernel: ArrayView3<Self::Data>) -> Result<Self::Output, Error>;
+    fn conv2d<U: Data<Elem=Self::Data>>(&self, kernel: ArrayBase<U, Ix3>) -> Result<Self::Output, Error>;
     /// Performs the convolution inplace mutating the containers data
     /// applies the default padding of zero padding
-    fn conv2d_inplace(&mut self, kernel: ArrayView3<Self::Data>) -> Result<(), Error>;
+    fn conv2d_inplace<U: Data<Elem=Self::Data>>(&mut self, kernel: ArrayBase<U, Ix3>) -> Result<(), Error>;
     /// Perform a convolution returning the resultant data
     /// applies the default padding of zero padding
-    fn conv2d_with_padding(
+    fn conv2d_with_padding<U: Data<Elem=Self::Data>>(
         &self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<U, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<Self::Output, Error>;
     /// Performs the convolution inplace mutating the containers data
     /// applies the default padding of zero padding
-    fn conv2d_inplace_with_padding(
+    fn conv2d_inplace_with_padding<U: Data<Elem=Self::Data>>(
         &mut self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<U, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<(), Error>;
 }
@@ -47,18 +47,18 @@ where
     type Data = T;
     type Output = Array<T, Ix3>;
 
-    fn conv2d(&self, kernel: ArrayView3<Self::Data>) -> Result<Self::Output, Error> {
+    fn conv2d<B: Data<Elem=T>>(&self, kernel: ArrayBase<B, Ix3>) -> Result<Self::Output, Error> {
         self.conv2d_with_padding(kernel, &ZeroPadding {})
     }
 
-    fn conv2d_inplace(&mut self, kernel: ArrayView3<Self::Data>) -> Result<(), Error> {
+    fn conv2d_inplace<B: Data<Elem=T>>(&mut self, kernel: ArrayBase<B, Ix3>) -> Result<(), Error> {
         self.assign(&self.conv2d_with_padding(kernel, &ZeroPadding {})?);
         Ok(())
     }
 
-    fn conv2d_with_padding(
+    fn conv2d_with_padding<B: Data<Elem=T>>(
         &self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<B, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<Self::Output, Error> {
         if self.shape()[2] != kernel.shape()[2] {
@@ -86,9 +86,9 @@ where
         }
     }
 
-    fn conv2d_inplace_with_padding(
+    fn conv2d_inplace_with_padding<B: Data<Elem=T>>(
         &mut self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<B, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<(), Error> {
         self.assign(&self.conv2d_with_padding(kernel, strategy)?);
@@ -105,7 +105,7 @@ where
     type Data = T;
     type Output = Image<T, C>;
 
-    fn conv2d(&self, kernel: ArrayView3<Self::Data>) -> Result<Self::Output, Error> {
+    fn conv2d<B: Data<Elem=T>>(&self, kernel: ArrayBase<B, Ix3>) -> Result<Self::Output, Error> {
         let data = self.data.conv2d(kernel)?;
         Ok(Self::Output {
             data,
@@ -113,13 +113,13 @@ where
         })
     }
 
-    fn conv2d_inplace(&mut self, kernel: ArrayView3<Self::Data>) -> Result<(), Error> {
+    fn conv2d_inplace<B: Data<Elem=T>>(&mut self, kernel: ArrayBase<B, Ix3>) -> Result<(), Error> {
         self.data.conv2d_inplace(kernel)
     }
 
-    fn conv2d_with_padding(
+    fn conv2d_with_padding<B: Data<Elem=T>>(
         &self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<B, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<Self::Output, Error> {
         let data = self.data.conv2d_with_padding(kernel, strategy)?;
@@ -129,9 +129,9 @@ where
         })
     }
 
-    fn conv2d_inplace_with_padding(
+    fn conv2d_inplace_with_padding<B: Data<Elem=T>>(
         &mut self,
-        kernel: ArrayView3<Self::Data>,
+        kernel: ArrayBase<B, Ix3>,
         strategy: &dyn PaddingStrategy<Self::Data>,
     ) -> Result<(), Error> {
         self.data.conv2d_inplace_with_padding(kernel, strategy)

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -159,8 +159,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate openblas_src;
-
     use super::affine;
     use super::*;
     use crate::core::colour_models::Gray;


### PR DESCRIPTION
This PR allows any ArrayBase to use as a kernel in convolution operations. It also fixes an issue I had with openblas-src on Windows (it doesn't build on Windows) by switching it out for `intel-mkl-src` via `ndarray-linalg = { version = "0.12", features = ["intel-mkl"] }` in the `dev-dependencies`. Note that it only uses the MKL for development. Downstream users can still choose their BLAS and LAPACK implementations separately. It will also use the system libraries if they are already installed.

I also made all the dependencies have `default-features = false` since we weren't using any features from any dependency. This avoids downstream users pulling in more dependency crates than they need to.

I also added more category slugs that were relevant to this project so people can discover it.

Let me know if you need any corrections.