### PR TITLE
Fixed threshold docs

### DIFF
--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -87,13 +87,15 @@ where
     }
 }
 
+/// Calculates Otsu's threshold.
 ///
-/// Calculates Otsu's threshold
-/// Works per channel, but currently
-/// assumes grayscale (see the error above if number of channels is > 1
-/// i.e. single channel; otherwise we need to output all 3 threshold values).
-/// Todo: Add optional nbins
+/// Works per channel, but currently assumes greyscale.
 ///
+/// See the Errors section for the `ThresholdOtsuExt` trait if the number of
+/// channels is greater than one (1), i.e., single channel; otherwise, we would
+/// need to output all three threshold values.
+///
+/// TODO: Add optional nbins
 fn calculate_threshold_otsu<T, U>(mat: &ArrayBase<U, Ix3>) -> Result<f64, Error>
 where
     U: Data<Elem = T>,

--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -18,31 +18,36 @@ use noisy_float::types::n64;
 
 /// Runs the Otsu Thresholding algorithm on a type `T`.
 pub trait ThresholdOtsuExt<T> {
-    /// The Otsu thresholding outputs a binary image.
+    /// The Otsu thresholding output is a binary image.
     type Output;
 
     /// Run the Otsu threshold algorithm.
     ///
-    /// Due to Otsu threshold algorithm specifying a greyscale image, all current
-    /// implementations assume a single channel image; otherwise, an error is
-    /// returned.
+    /// Due to Otsu threshold algorithm specifying a greyscale image, all
+    /// current implementations assume a single channel image; otherwise, an
+    /// error is returned.
     ///
     /// # Errors
     ///
-    /// Returns a `ChannelDimensionMismatch` error if more than one channel exists.
+    /// Returns a `ChannelDimensionMismatch` error if more than one channel
+    /// exists.
     fn threshold_otsu(&self) -> Result<Self::Output, Error>;
 }
 
-/// Runs the Mean Thresholding algorithm on a type T
+/// Runs the Mean Thresholding algorithm on a type `T`.
 pub trait ThresholdMeanExt<T> {
-    /// Output type, this is different as the Mean thresholding output is a
-    /// binary image
+    /// The Mean thresholding output is a binary image.
     type Output;
 
-    /// Run the Otsu threshold detection algorithm with the
-    /// given parameters. Due to Otsu being specified as working
-    /// on greyscale images all current implementations
-    /// assume a single channel image returning an error otherwise.
+    /// Run the Mean threshold algorithm.
+    ///
+    /// This assumes the image is a single channel image, i.e., a greyscale
+    /// image; otherwise, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ChannelDimensionMismatch` error if more than one channel
+    /// exists.
     fn threshold_mean(&self) -> Result<Self::Output, Error>;
 }
 

--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -16,21 +16,27 @@ use assert_approx_eq::assert_approx_eq;
 #[cfg(test)]
 use noisy_float::types::n64;
 
-/// Runs the Otsu Thresholding algorithm on a type T
+/// Runs the Otsu Thresholding algorithm on a type `T`.
 pub trait ThresholdOtsuExt<T> {
-    /// Output type, this is different as Otsu outputs a binary image
+    /// The Otsu thresholding outputs a binary image.
     type Output;
 
-    /// Run the Otsu threshold detection algorithm with the
-    /// given parameters. Due to Otsu being specified as working
-    /// on greyscale images all current implementations
-    /// assume a single channel image returning an error otherwise.
+    /// Run the Otsu threshold algorithm.
+    ///
+    /// Due to Otsu threshold algorithm specifying a greyscale image, all current
+    /// implementations assume a single channel image; otherwise, an error is
+    /// returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ChannelDimensionMismatch` error if more than one channel exists.
     fn threshold_otsu(&self) -> Result<Self::Output, Error>;
 }
 
 /// Runs the Mean Thresholding algorithm on a type T
 pub trait ThresholdMeanExt<T> {
-    /// Output type, this is different as Otsu outputs a binary image
+    /// Output type, this is different as the Mean thresholding output is a
+    /// binary image
     type Output;
 
     /// Run the Otsu threshold detection algorithm with the

--- a/src/processing/threshold.rs
+++ b/src/processing/threshold.rs
@@ -16,7 +16,7 @@ use assert_approx_eq::assert_approx_eq;
 #[cfg(test)]
 use noisy_float::types::n64;
 
-/// Runs the Otsu Thresholding algorithm on a type `T`.
+/// Runs the Otsu thresholding algorithm on a type `T`.
 pub trait ThresholdOtsuExt<T> {
     /// The Otsu thresholding output is a binary image.
     type Output;
@@ -34,7 +34,7 @@ pub trait ThresholdOtsuExt<T> {
     fn threshold_otsu(&self) -> Result<Self::Output, Error>;
 }
 
-/// Runs the Mean Thresholding algorithm on a type `T`.
+/// Runs the Mean thresholding algorithm on a type `T`.
 pub trait ThresholdMeanExt<T> {
     /// The Mean thresholding output is a binary image.
     type Output;


### PR DESCRIPTION
The documentation for the `ThresholdMeanExt` trait appeared to be copy-n-pasted from the `ThresholdOtsuExt` trait. I thought I would take this opportunity to also clean up the doc comments and fix some formatting, too. PR submitted with appreciate from all contributors and developers for the implementation and crate. Thank you!