### PR TITLE
Added serde support for `Image` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ ndarray-linalg = { version = "0.14", features = ["intel-mkl"] }
 # it is a dependency of intel-mkl-tool, we pin it to temporary solve
 # https://github.com/rust-math/intel-mkl-src/issues/68
 anyhow = "<1.0.49"
+serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ intel-mkl = ["ndarray-linalg/intel-mkl"]
 transform = ["ndarray-linalg"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.15", default-features = false, features = ["serde"] }
 ndarray-stats = { version = "0.5", default-features = false }
 ndarray-linalg = { version = "0.14", default-features = false, optional = true }
 noisy_float = { version = "0.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+serde = { version = "1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 ndarray = { version = "0.15", features = ["approx"] }

--- a/src/core/colour_models.rs
+++ b/src/core/colour_models.rs
@@ -60,6 +60,8 @@ pub struct Generic5;
 /// ColourModel trait, this trait reports base parameters for different colour
 /// models
 pub trait ColourModel {
+    const NAME: &'static str;
+
     /// Number of colour channels for a type.
     fn channels() -> usize {
         3
@@ -816,48 +818,89 @@ where
     }
 }
 
-impl ColourModel for RGB {}
-impl ColourModel for HSV {}
-impl ColourModel for HSI {}
-impl ColourModel for HSL {}
-impl ColourModel for YCrCb {}
-impl ColourModel for CIEXYZ {}
-impl ColourModel for CIELAB {}
-impl ColourModel for CIELUV {}
+impl ColourModel for RGB {
+    const NAME: &'static str = "RGB";
+}
+
+impl ColourModel for HSV {
+    const NAME: &'static str = "HSV";
+}
+
+impl ColourModel for HSI {
+    const NAME: &'static str = "HSI";
+}
+
+impl ColourModel for HSL {
+    const NAME: &'static str = "HSL";
+}
+
+impl ColourModel for YCrCb {
+    const NAME: &'static str = "YCrCb";
+}
+
+impl ColourModel for CIEXYZ {
+    const NAME: &'static str = "CIEXYZ";
+}
+
+impl ColourModel for CIELAB {
+    const NAME: &'static str = "CIELAB";
+}
+
+impl ColourModel for CIELUV {
+    const NAME: &'static str = "CIELUV";
+}
 
 impl ColourModel for Gray {
+    const NAME: &'static str = "Gray";
+
     fn channels() -> usize {
         1
     }
 }
 
 impl ColourModel for Generic1 {
+    const NAME: &'static str = "Generic1";
+
     fn channels() -> usize {
         1
     }
 }
+
 impl ColourModel for Generic2 {
+    const NAME: &'static str = "Generic2";
+
     fn channels() -> usize {
         2
     }
 }
+
 impl ColourModel for Generic3 {
+    const NAME: &'static str = "Generic3";
+
     fn channels() -> usize {
         3
     }
 }
+
 impl ColourModel for Generic4 {
+    const NAME: &'static str = "Generic4";
+
     fn channels() -> usize {
         4
     }
 }
+
 impl ColourModel for Generic5 {
+    const NAME: &'static str = "Generic5";
+
     fn channels() -> usize {
         5
     }
 }
 
 impl ColourModel for RGBA {
+    const NAME: &'static str = "RGBA";
+
     fn channels() -> usize {
         4
     }

--- a/src/core_serde.rs
+++ b/src/core_serde.rs
@@ -6,16 +6,29 @@ use serde::{Serialize, Serializer};
 impl<A, T, C> Serialize for ImageBase<T, C>
 where
     A: Serialize,
-    T: Data<Elem = A> + Serialize,
+    T: Data<Elem = A>,
     C: ColourModel,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Image", 2)?;
+        let mut state = serializer.serialize_struct("ImageBase", 2)?;
         state.serialize_field("data", &self.data)?;
-        state.serialize_field("model", &self.model)?;
+        state.serialize_field("model", C::NAME)?;
         state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::{Image, RGB};
+
+    #[test]
+    fn serialize_image_base() {
+        const EXPECTED: &str = r#"{"data":{"v":1,"dim":[2,3,3],"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"model":"RGB"}"#;
+        let i = Image::<u8, RGB>::new(2, 3);
+        let actual = serde_json::to_string(&i).expect("Serialized RGB image");
+        assert_eq!(actual, EXPECTED);
     }
 }

--- a/src/core_serde.rs
+++ b/src/core_serde.rs
@@ -1,0 +1,21 @@
+use crate::core::{ColourModel, ImageBase};
+use ndarray::Data;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+
+impl<A, T, C> Serialize for ImageBase<T, C>
+where
+    A: Serialize,
+    T: Data<Elem = A> + Serialize,
+    C: ColourModel,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Image", 2)?;
+        state.serialize_field("data", &self.data)?;
+        state.serialize_field("model", &self.model)?;
+        state.end()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 
 /// The core of `ndarray-vision` contains the `Image` type and colour models
 pub mod core;
+mod core_serde;
 /// Image enhancement intrinsics and algorithms
 #[cfg(feature = "enhancement")]
 pub mod enhancement;


### PR DESCRIPTION
Resolves #54.

A feature flag still needs to be added, but I wanted to share what I have so far to make sure I am on the right track.

I am not sure if this is a good implementation because I have added (de)serialization of the colour model as a string but during deserialization is actually never used. The colour model must be known ahead of time and used for the type annotation. The type is not determined from the `"model"` field. See the unit test for some context.

```rust
    #[test]
    fn deserialize_image_base() {
        const EXPECTED: &str = r#"{"data":{"v":1,"dim":[2,3,3],"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"model":"RGB"}"#;
        let actual: Image<u8, RGB> = serde_json::from_str(EXPECTED).expect("Deserialized image");
        assert_eq!(actual.model, PhantomData);
    }
```

If the model is _not_ `RGB` then an error occurs instead of creating an image based on the colour model that is specified, but maybe this is correct way to do this? This is my first time really diving into manually implementing (de)serialization. Is there a way to deserialize into a "generic" Image.

