### PR TITLE
Docs don't show right

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
           cargo check --no-default-features
       - name: test
         run: |
-          cargo test 
+          cargo test --features=intel-mkl
       - name: check formatting
         run: cargo fmt -- --check
       - name: code-coverage
         run: |
           cargo install cargo-tarpaulin --force --git https://github.com/xd009642/tarpaulin --branch develop
-          cargo tarpaulin --force-clean --coveralls ${{ secrets.COVERALLS_TOKEN }}
+          cargo tarpaulin --features=intel-mkl --force-clean --coveralls ${{ secrets.COVERALLS_TOKEN }}
         if: matrix.target == 'x86_64-unknown-linux-gnu' && matrix.version == 'nightly'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## [0.5.0]
+## [0.5.1] 2023-09-04
+### Changed
+- Updated dependencies and attempt to fix doc.rs rendering
+
+## [0.5.0] 2023-07-23
 ### Added
 - The `ThresholdApplyExt` trait to apply user-defined threshold
 - The `threshold_apply` method to the `ArrayBase` and `Image` types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ transform = ["ndarray-linalg"]
 [dependencies]
 ndarray = { version = "0.15", default-features = false }
 ndarray-stats = { version = "0.5", default-features = false }
-ndarray-linalg = { version = "0.14", default-features = false, optional = true }
+ndarray-linalg = { version = "0.16", default-features = false, optional = true }
 noisy_float = { version = "0.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
@@ -35,7 +35,6 @@ rand = "0.8"
 assert_approx_eq = "1.1.0"
 approx = "0.4"
 noisy_float = "0.2"
-png = "0.16"
+png = "0.17"
 # it is a dependency of intel-mkl-tool, we pin it to temporary solve
 # https://github.com/rust-math/intel-mkl-src/issues/68
-anyhow = "<1.0.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndarray-vision"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["xd009642 <danielmckenna93@gmail.com>"]
 description = "A computer vision library built on top of ndarray"
 repository = "https://github.com/xd009642/ndarray-vision"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ assert_approx_eq = "1.1.0"
 approx = "0.4"
 noisy_float = "0.2"
 png = "0.16"
-ndarray-linalg = { version = "0.14", features = ["intel-mkl"] }
 # it is a dependency of intel-mkl-tool, we pin it to temporary solve
 # https://github.com/rust-math/intel-mkl-src/issues/68
 anyhow = "<1.0.49"

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -45,7 +45,7 @@ fn main() {
     let w = &mut BufWriter::new(file);
 
     let mut encoder = png::Encoder::new(w, transformed.cols() as u32, transformed.rows() as u32);
-    encoder.set_color(png::ColorType::RGB);
+    encoder.set_color(png::ColorType::Rgb);
     encoder.set_depth(png::BitDepth::Eight);
 
     println!(


### PR DESCRIPTION
Published docs don't show right because of the intel-mkl download and docs.rs being sandboxed when generating docs. So because of this disable the feature as a dev dependency and manually pass it into the actions etc